### PR TITLE
feat: Adding automatic release and versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Overview
+
+## 📋 Pull Request Checklist
+
+Please review and check all the following:
+
+- [ ] I have added an overview of the changes
+- [ ] I have tested my changes locally
+- [ ] I have updated documentation (if applicable)
+
+---
+
+## 🚀 Versioning (Required for GitVersion)
+
+- [ ] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
+  - `#major` – breaking change
+  - `#minor` – new feature
+  - `#patch` – bug fix or minor update  
+  - _If omitted, the version will default to_ `patch`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,37 +2,50 @@ name: Release Python Package
 
 on:
   push:
-    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+    branches:
+      - main
+      - develop/**
 
 jobs:
   tag-release:
-    runs-on: ubuntu-24.04
-    outputs:
-      version: ${{ steps.set-version.outputs.version }}
+    name: Generate Release
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Parse version info from tag
-        id: set-version
-        run: |
-          # GITHUB_REF is like refs/tags/v2.3.5, so strip the first 11 chars
-          VERSION=${GITHUB_REF:11}
-          MAJOR=$(echo "$VERSION" | cut -d . -f 1)
-          MINOR=$(echo "$VERSION" | cut -d . -f 2)
-          PATCH=$(echo "$VERSION" | cut -d . -f 3)
-
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          echo "version=$VERSION" >> $GITHUB_ENV
-          echo "version_major=$MAJOR" >> $GITHUB_ENV
-          echo "version_minor=$MINOR" >> $GITHUB_ENV
-          echo "version_patch=$PATCH" >> $GITHUB_ENV
+      - name: Create GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v3.2.1
+        with:
+          versionSpec: '5.12.0'
+      - name: Run GitVersion
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v3.2.1
+        with:
+          useConfigFile: true
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          tag_name: ${{ steps.gitversion.outputs.semVer }}
+          name: Release ${{ steps.gitversion.outputs.semVer }}
+          generate_release_notes: true
+          prerelease: ${{ contains(steps.gitversion.outputs.semVer, '-') }}
 
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: tag-release
     env:
-      version: ${{ needs.tag-release.outputs.version }}
+      version: ${{ steps.gitversion.outputs.majorMinorPatch }}
 
     steps:
       - uses: actions/checkout@v4

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,24 @@
+mode: Mainline
+commit-message-incrementing: Enabled
+branches:
+  main:
+    regex: ^main$
+    increment: Patch # Default to patch release
+    prevent-increment-of-merged-branch-version: true
+    track-merge-target: false
+    is-mainline: true
+  release:
+    regex: ^develop[/-]
+    tag: canary
+    increment: Patch
+    is-source-branch-for:
+      - main
+    track-merge-target: false
+    prevent-increment-of-merged-branch-version: true
+    tracks-release-branches: false
+    is-release-branch: true
+merge-message-formats:
+  # Auto-detects increment type from commits
+  major: '#major'
+  minor: '#minor'
+  patch: '#patch'


### PR DESCRIPTION
The following are added with this MR:

- configured [GitVersion](https://gitversion.net/) to process a comment and identify the release version based on SemVer. Hence, if the comment contains #major, #minor or #patch the version will be increased accordingly. If nothing is specified, the default is a patch release.
- added a checklist template to the following PRs.
- configured [GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow) token to handle the releases
Closes #6 